### PR TITLE
fix: eliminate slow loading states by streaming deferred data and removing redundant DB query

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,9 +3,6 @@ import { building } from '$app/environment';
 import { sequence } from '@sveltejs/kit/hooks';
 import { auth } from '$lib/server/auth';
 import { svelteKitHandler } from 'better-auth/svelte-kit';
-import { db } from '$lib/server/db';
-import { user } from '$lib/server/db/schema';
-import { eq } from 'drizzle-orm';
 
 const handleRequestId: Handle = async ({ event, resolve }) => {
 	event.locals.requestId = crypto.randomUUID();
@@ -19,13 +16,11 @@ const handleBetterAuth: Handle = async ({ event, resolve }) => {
 		event.locals.session = session.session;
 		event.locals.user = session.user;
 
-		const rows = await db
-			.select({ householdId: user.householdId })
-			.from(user)
-			.where(eq(user.id, session.user.id));
-
-		if (rows.length > 0 && rows[0].householdId) {
-			event.locals.householdId = rows[0].householdId;
+		// better-auth already fetches the full user row; grab householdId
+		// from it instead of issuing a second DB query on every request.
+		const householdId = (session.user as Record<string, unknown>).householdId;
+		if (typeof householdId === 'string' && householdId) {
+			event.locals.householdId = householdId;
 		}
 	}
 

--- a/src/routes/(app)/inventory/+page.server.ts
+++ b/src/routes/(app)/inventory/+page.server.ts
@@ -31,23 +31,26 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.user.id;
 	const householdId = locals.householdId ?? null;
 	const ctx = { userId, requestId: locals.requestId, route: '/inventory' };
-	const [items, trashedItems] = await Promise.all([
-		appRuntime.runPromise(
-			withRequestLogging(findAllFoodItems(householdId, userId), { ...ctx, useCase: 'findAllFoodItems' }).pipe(
-				Effect.orDie
-			)
-		),
-		appRuntime.runPromise(
+
+	// Await critical data for initial render; stream the rest
+	const items = await appRuntime.runPromise(
+		withRequestLogging(findAllFoodItems(householdId, userId), { ...ctx, useCase: 'findAllFoodItems' }).pipe(
+			Effect.orDie
+		)
+	);
+
+	return {
+		items,
+		trashedItems: appRuntime.runPromise(
 			withRequestLogging(findTrashedFoodItems(householdId, userId), {
 				...ctx,
 				useCase: 'findTrashedFoodItems'
 			}).pipe(Effect.orDie)
+		),
+		restockItems: Effect.runPromise(
+			getRestockItems(items, DEFAULT_EXPIRATION_CONFIG).pipe(Effect.orDie)
 		)
-	]);
-	const restockItems = await Effect.runPromise(
-		getRestockItems(items, DEFAULT_EXPIRATION_CONFIG).pipe(Effect.orDie)
-	);
-	return { items, trashedItems, restockItems };
+	};
 };
 
 function parseItemFields(

--- a/src/routes/(app)/inventory/+page.svelte
+++ b/src/routes/(app)/inventory/+page.svelte
@@ -411,20 +411,28 @@
 						: 'text-[#8a8279] hover:bg-[#f0ebe4] hover:text-[#3a3632]'}"
 				>
 					{tab.label}
-					{#if tab.id === 'trash' && data.trashedItems.length > 0}
-						<span
-							class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white"
-						>
-							{data.trashedItems.length}
-						</span>
+					{#if tab.id === 'trash'}
+						{#await data.trashedItems then trashedItems}
+							{#if trashedItems.length > 0}
+								<span
+									class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white"
+								>
+									{trashedItems.length}
+								</span>
+							{/if}
+						{/await}
 					{/if}
-					{#if tab.id === 'restock' && data.restockItems.length > 0}
-						<span
-							class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold text-[#1a1714]"
-							style="background-color: #c4a46a;"
-						>
-							{data.restockItems.length}
-						</span>
+					{#if tab.id === 'restock'}
+						{#await data.restockItems then restockItems}
+							{#if restockItems.length > 0}
+								<span
+									class="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold text-[#1a1714]"
+									style="background-color: #c4a46a;"
+								>
+									{restockItems.length}
+								</span>
+							{/if}
+						{/await}
 					{/if}
 				</button>
 			{/each}
@@ -438,12 +446,15 @@
 
 	<!-- Restock tab content -->
 	{#if activeTab === 'restock'}
-		{#if data.restockItems.length === 0}
+		{#await data.restockItems}
+			<p class="mb-10 text-sm text-[#8a8279]">Loading restock items...</p>
+		{:then restockItems}
+		{#if restockItems.length === 0}
 			<p class="mb-10 text-sm text-[#8a8279]">Nothing needs restocking right now.</p>
 		{:else}
 			<section class="mb-10">
 				<ul class="divide-y divide-[#e8e2d9] rounded-xl border border-[#e8e2d9] bg-white">
-					{#each data.restockItems as restockItem (restockItem.foodItem.id)}
+					{#each restockItems as restockItem (restockItem.foodItem.id)}
 						{@const statusColors = {
 							expired: 'bg-red-100 text-red-700 border-red-200',
 							'expiring-soon': 'bg-yellow-100 text-yellow-700 border-yellow-200'
@@ -528,15 +539,19 @@
 				</ul>
 			</section>
 		{/if}
+		{/await}
 
 		<!-- Trash tab content -->
 	{:else if activeTab === 'trash'}
-		{#if data.trashedItems.length === 0}
+		{#await data.trashedItems}
+			<p class="mb-10 text-sm text-[#8a8279]">Loading trashed items...</p>
+		{:then trashedItems}
+		{#if trashedItems.length === 0}
 			<p class="mb-10 text-sm text-[#8a8279]">No recently trashed items.</p>
 		{:else}
 			<section class="mb-10">
 				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{#each data.trashedItems as item (item.id)}
+					{#each trashedItems as item (item.id)}
 						<article
 							class="rounded-xl border border-[#e8e2d9] bg-white p-6 opacity-70 transition-all duration-200"
 						>
@@ -576,6 +591,7 @@
 				</div>
 			</section>
 		{/if}
+		{/await}
 	{:else}
 		<!-- Hidden file input for receipt scan (?scan=receipt deep-link and bottom sheet) -->
 		<input

--- a/src/routes/(app)/recipes/+page.server.ts
+++ b/src/routes/(app)/recipes/+page.server.ts
@@ -21,17 +21,12 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.user!.id;
 	const householdId = locals.householdId ?? null;
 	const ctx = { userId, requestId: locals.requestId, route: '/recipes' };
-	const [recipes, trashedRecipes, foodItems] = await Promise.all([
+	// Await critical data for initial render; stream trash tab data
+	const [recipes, foodItems] = await Promise.all([
 		appRuntime.runPromise(
 			withRequestLogging(findAllRecipes(householdId, userId), { ...ctx, useCase: 'findAllRecipes' }).pipe(
 				Effect.orDie
 			)
-		),
-		appRuntime.runPromise(
-			withRequestLogging(findTrashedRecipes(householdId, userId), {
-				...ctx,
-				useCase: 'findTrashedRecipes'
-			}).pipe(Effect.orDie)
 		),
 		appRuntime.runPromise(
 			withRequestLogging(findAllFoodItems(householdId, userId), {
@@ -40,7 +35,17 @@ export const load: PageServerLoad = async ({ locals }) => {
 			}).pipe(Effect.orDie)
 		)
 	]);
-	return { recipes, trashedRecipes, foodItems };
+
+	return {
+		recipes,
+		foodItems,
+		trashedRecipes: appRuntime.runPromise(
+			withRequestLogging(findTrashedRecipes(householdId, userId), {
+				...ctx,
+				useCase: 'findTrashedRecipes'
+			}).pipe(Effect.orDie)
+		)
+	};
 };
 
 function parseIngredients(formData: FormData): CreateIngredientInput[] | null {

--- a/src/routes/(app)/recipes/+page.svelte
+++ b/src/routes/(app)/recipes/+page.svelte
@@ -710,13 +710,16 @@
 			{/if}
 		{:else}
 			<!-- Trash tab -->
-			{#if data.trashedRecipes.length === 0}
+			{#await data.trashedRecipes}
+				<p class="text-sm text-[#8a7a6a]">Loading trashed recipes...</p>
+			{:then trashedRecipes}
+			{#if trashedRecipes.length === 0}
 				<div class="rounded-2xl border border-dashed border-[#d8cfc4] bg-white p-10 text-center">
 					<p class="text-[#8a7a6a]">Trash is empty.</p>
 				</div>
 			{:else}
 				<div class="flex flex-col gap-3">
-					{#each data.trashedRecipes as recipe (recipe.id)}
+					{#each trashedRecipes as recipe (recipe.id)}
 						<div
 							class="rounded-2xl border border-[#e8e2d9] bg-white px-5 py-4 opacity-60 shadow-sm"
 						>
@@ -746,6 +749,7 @@
 					{/each}
 				</div>
 			{/if}
+			{/await}
 		{/if}
 	{/if}
 </main>

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -20,32 +20,28 @@ import {
 } from '$lib/domain/household/errors.js';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
+	// Await household (gates the section), stream members list
 	let household = null;
-	let members: { id: string; name: string; role: 'owner' | 'member' }[] = [];
-
 	if (locals.householdId) {
-		const [hh, mems] = await Promise.all([
-			appRuntime
-				.runPromise(
-					Effect.gen(function* () {
-						const repo = yield* HouseholdRepository;
-						return yield* repo.findByUserId(locals.user!.id);
-					})
-				)
-				.catch(() => null),
-			appRuntime
-				.runPromise(Effect.either(getMembers(locals.householdId)))
-				.then((r) => (r._tag === 'Right' ? r.right : []))
-				.catch(() => [])
-		]);
-		household = hh;
-		members = mems;
+		household = await appRuntime
+			.runPromise(
+				Effect.gen(function* () {
+					const repo = yield* HouseholdRepository;
+					return yield* repo.findByUserId(locals.user!.id);
+				})
+			)
+			.catch(() => null);
 	}
 
 	return {
 		user: locals.user!,
 		household,
-		members,
+		members: locals.householdId
+			? appRuntime
+					.runPromise(Effect.either(getMembers(locals.householdId)))
+					.then((r) => (r._tag === 'Right' ? r.right : []))
+					.catch(() => [] as { id: string; name: string; role: 'owner' | 'member' }[])
+			: Promise.resolve([] as { id: string; name: string; role: 'owner' | 'member' }[]),
 		inviteGenerated: url.searchParams.get('inviteGenerated') ?? null
 	};
 };

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -53,8 +53,17 @@
 		setTimeout(() => (copied = false), 2000);
 	}
 
+	// Resolve streamed members into reactive state
+	type Member = { id: string; name: string; role: 'owner' | 'member' };
+	let resolvedMembers = $state<Member[]>([]);
+
+	$effect(() => {
+		const promise = data.members;
+		promise.then((m) => { resolvedMembers = m; });
+	});
+
 	const isOwner = $derived(
-		data.members.find((m) => m.id === data.user.id)?.role === 'owner'
+		resolvedMembers.find((m) => m.id === data.user.id)?.role === 'owner'
 	);
 
 	let householdName = $state(data.household?.name ?? '');
@@ -283,7 +292,7 @@
 					<p class="mb-2 text-sm text-red-600">{transferError}</p>
 				{/if}
 				<ul class="divide-y divide-[#f0ebe4]">
-					{#each data.members as member}
+					{#each resolvedMembers as member}
 						<li class="flex items-center justify-between py-2.5">
 							<div>
 								<span class="text-sm font-medium text-[#1a1714]">{member.name}</span>
@@ -426,7 +435,7 @@
 						{leaveSubmitting ? 'Leaving…' : 'Leave household'}
 					</button>
 				</form>
-				{#if isOwner && data.members.length > 1}
+				{#if isOwner && resolvedMembers.length > 1}
 					<p class="mt-1.5 text-xs text-[#8a8279]">
 						Transfer ownership before leaving.
 					</p>

--- a/src/routes/(app)/shop/+page.server.ts
+++ b/src/routes/(app)/shop/+page.server.ts
@@ -13,13 +13,15 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.user!.id;
 	const householdId = locals.householdId ?? null;
 	const ctx = { userId, requestId: locals.requestId, route: '/shop' };
-	const items = await appRuntime.runPromise(
-		withRequestLogging(generateShoppingList(householdId, userId), {
-			...ctx,
-			useCase: 'generateShoppingList'
-		}).pipe(Effect.orDie)
-	);
-	return { items };
+	// Stream the expensive shopping list generation so the page shell renders immediately
+	return {
+		items: appRuntime.runPromise(
+			withRequestLogging(generateShoppingList(householdId, userId), {
+				...ctx,
+				useCase: 'generateShoppingList'
+			}).pipe(Effect.orDie)
+		)
+	};
 };
 
 export const actions: Actions = {

--- a/src/routes/(app)/shop/+page.svelte
+++ b/src/routes/(app)/shop/+page.svelte
@@ -21,12 +21,25 @@
 		goto('/shop', { replaceState: true });
 	}
 
+	// Resolve streamed items into reactive state
+	type ShoppingItem = Awaited<typeof data.items>[number];
+	let resolvedItems = $state<ShoppingItem[]>([]);
+	let itemsLoaded = $state(false);
+
+	$effect(() => {
+		const promise = data.items;
+		promise.then((items) => {
+			resolvedItems = items;
+			itemsLoaded = true;
+		});
+	});
+
 	// Optimistic overrides: id → intended checked state, set immediately on click
 	const optimisticOverrides = $state(new Map<number, boolean>());
 
 	// When server data refreshes, clear overrides whose state the server has caught up with
 	$effect(() => {
-		const items = data.items;
+		const items = resolvedItems;
 		untrack(() => {
 			for (const [id, optimistic] of optimisticOverrides) {
 				const serverItem = items.find((i) => i.id === id);
@@ -39,17 +52,17 @@
 
 	function isChecked(id: number): boolean {
 		if (optimisticOverrides.has(id)) return optimisticOverrides.get(id)!;
-		return data.items.find((i) => i.id === id)?.checked ?? false;
+		return resolvedItems.find((i) => i.id === id)?.checked ?? false;
 	}
 
 	function handleToggle(id: number, nextChecked: boolean) {
 		optimisticOverrides.set(id, nextChecked);
 	}
 
-	const uncheckedItems = $derived(data.items.filter((i) => !isChecked(i.id)));
-	const checkedItems = $derived(data.items.filter((i) => isChecked(i.id)));
+	const uncheckedItems = $derived(resolvedItems.filter((i) => !isChecked(i.id)));
+	const checkedItems = $derived(resolvedItems.filter((i) => isChecked(i.id)));
 
-	const hasCheckedItems = $derived(data.items.some((i) => isChecked(i.id)));
+	const hasCheckedItems = $derived(resolvedItems.some((i) => isChecked(i.id)));
 </script>
 
 <svelte:head>
@@ -68,7 +81,11 @@
 		</h1>
 	</div>
 
-	{#if data.items.length === 0}
+	{#if !itemsLoaded}
+		<div class="rounded-2xl border border-dashed border-[#d8cfc4] bg-white p-10 text-center">
+			<p class="text-[#8a7a6a]">Loading shopping list...</p>
+		</div>
+	{:else if resolvedItems.length === 0}
 		<div class="rounded-2xl border border-dashed border-[#d8cfc4] bg-white p-10 text-center">
 			<p class="mb-1 text-[#8a7a6a]">Nothing to shop for.</p>
 			<p class="text-sm text-[#b0a090]">Items will appear here when food is expiring or pinned recipes have missing ingredients.</p>


### PR DESCRIPTION
The hooks.server.ts handler was querying the DB for householdId on every
single request despite better-auth already fetching the full user row.
Page loaders were awaiting all data (including rarely-seen trash tabs)
before rendering anything. Now non-critical data is returned as promises
and streamed via {#await} blocks so the page shell renders immediately.

https://claude.ai/code/session_011fER1eKbVrX4K7hSoGkZiV