### PR TITLE
Fix bottom nav scrolling/stretching on non-PWA mobile browsers

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -20,7 +20,7 @@
 	];
 </script>
 
-<div class="flex min-h-screen flex-col bg-[#f8f6f3] font-[Nunito_Sans,sans-serif]">
+<div class="flex min-h-dvh flex-col bg-[#f8f6f3] font-[Nunito_Sans,sans-serif] overscroll-y-none">
 	<AppHeader user={data.user} />
 	{@render children()}
 	<nav class="fixed right-0 bottom-0 left-0 z-40 border-t border-[#e8e2d9] bg-white pb-[calc(env(safe-area-inset-bottom)/2)]">

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+
+html,
+body {
+	overscroll-behavior-y: none;
+}


### PR DESCRIPTION
Use min-h-dvh instead of min-h-screen to account for dynamic browser
chrome, and disable overscroll behavior to prevent rubber-banding.

https://claude.ai/code/session_017L3bDnXRi5MYAzMEgQB4ax