### PR TITLE
feat: add subscription domain layer and server-side scan gate (#112)

### DIFF
--- a/drizzle/0001_harsh_bedlam.sql
+++ b/drizzle/0001_harsh_bedlam.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "complementary" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1097 @@
+{
+  "id": "5dd6befb-3b93-41b0-a408-119c82b58a6f",
+  "prevId": "c6ecc499-9426-4cce-8cf7-5d50edbdde85",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.canonical_ingredient": {
+      "name": "canonical_ingredient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_category": {
+          "name": "unit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "canonical_ingredient_name_unique": {
+          "name": "canonical_ingredient_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.food_item": {
+      "name": "food_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_location": {
+          "name": "storage_location",
+          "type": "storage_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_value": {
+          "name": "quantity_value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_unit": {
+          "name": "quantity_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_ingredient_id": {
+          "name": "canonical_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "food_item_user_id_user_id_fk": {
+          "name": "food_item_user_id_user_id_fk",
+          "tableFrom": "food_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_item_household_id_household_id_fk": {
+          "name": "food_item_household_id_household_id_fk",
+          "tableFrom": "food_item",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "food_item_canonical_ingredient_id_canonical_ingredient_id_fk": {
+          "name": "food_item_canonical_ingredient_id_canonical_ingredient_id_fk",
+          "tableFrom": "food_item",
+          "tableTo": "canonical_ingredient",
+          "columnsFrom": [
+            "canonical_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_user_id_user_id_fk": {
+          "name": "recipe_user_id_user_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_household_id_household_id_fk": {
+          "name": "recipe_household_id_household_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ingredient": {
+      "name": "recipe_ingredient",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_ingredient_id": {
+          "name": "canonical_ingredient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_value": {
+          "name": "quantity_value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_unit": {
+          "name": "quantity_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_ingredient_recipe_id_recipe_id_fk": {
+          "name": "recipe_ingredient_recipe_id_recipe_id_fk",
+          "tableFrom": "recipe_ingredient",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ingredient_canonical_ingredient_id_canonical_ingredient_id_fk": {
+          "name": "recipe_ingredient_canonical_ingredient_id_canonical_ingredient_id_fk",
+          "tableFrom": "recipe_ingredient",
+          "tableTo": "canonical_ingredient",
+          "columnsFrom": [
+            "canonical_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_note": {
+      "name": "recipe_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipe_note_recipe_id_recipe_id_fk": {
+          "name": "recipe_note_recipe_id_recipe_id_fk",
+          "tableFrom": "recipe_note",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_list_item": {
+      "name": "shopping_list_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_key": {
+          "name": "canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked": {
+          "name": "checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "shopping_list_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_restock_item_id": {
+          "name": "source_restock_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_recipe_names": {
+          "name": "source_recipe_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_storage_location": {
+          "name": "carried_storage_location",
+          "type": "storage_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_value": {
+          "name": "quantity_value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_unit": {
+          "name": "quantity_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shopping_list_item_user_id_user_id_fk": {
+          "name": "shopping_list_item_user_id_user_id_fk",
+          "tableFrom": "shopping_list_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shopping_list_item_household_id_household_id_fk": {
+          "name": "shopping_list_item_household_id_household_id_fk",
+          "tableFrom": "shopping_list_item",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shopping_list_item_household_id_canonical_key_unique": {
+          "name": "shopping_list_item_household_id_canonical_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "household_id",
+            "canonical_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task": {
+      "name": "task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_user_id_user_id_fk": {
+          "name": "task_user_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_household_id_household_id_fk": {
+          "name": "task_household_id_household_id_fk",
+          "tableFrom": "task",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household": {
+      "name": "household",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_expires_at": {
+          "name": "invite_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_role": {
+          "name": "household_role",
+          "type": "household_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complementary": {
+          "name": "complementary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_household_id_household_id_fk": {
+          "name": "user_household_id_household_id_fk",
+          "tableFrom": "user",
+          "tableTo": "household",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.shopping_list_source_type": {
+      "name": "shopping_list_source_type",
+      "schema": "public",
+      "values": [
+        "restock",
+        "recipe"
+      ]
+    },
+    "public.storage_location": {
+      "name": "storage_location",
+      "schema": "public",
+      "values": [
+        "pantry",
+        "fridge",
+        "freezer"
+      ]
+    },
+    "public.tracking_type": {
+      "name": "tracking_type",
+      "schema": "public",
+      "values": [
+        "amount",
+        "count"
+      ]
+    },
+    "public.household_role": {
+      "name": "household_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775337961774,
       "tag": "0000_plain_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775372038360,
+      "tag": "0001_harsh_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 import type { User, Session } from 'better-auth/minimal';
+import type { SubscriptionTier, SubscriptionStatus } from '$lib/domain/subscription/subscription.js';
 
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
@@ -9,6 +10,7 @@ declare global {
 			session?: Session;
 			requestId: string;
 			householdId?: string;
+			subscription: { tier: SubscriptionTier; status: SubscriptionStatus; complementary: boolean };
 		}
 
 		// interface Error {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -16,12 +16,23 @@ const handleBetterAuth: Handle = async ({ event, resolve }) => {
 		event.locals.session = session.session;
 		event.locals.user = session.user;
 
+		const fullUser = session.user as Record<string, unknown>;
+
 		// better-auth already fetches the full user row; grab householdId
 		// from it instead of issuing a second DB query on every request.
-		const householdId = (session.user as Record<string, unknown>).householdId;
+		const householdId = fullUser.householdId;
 		if (typeof householdId === 'string' && householdId) {
 			event.locals.householdId = householdId;
 		}
+
+		const complementary = fullUser.complementary === true;
+		event.locals.subscription = {
+			tier: complementary ? 'solo' : 'free',
+			status: 'active',
+			complementary
+		};
+	} else {
+		event.locals.subscription = { tier: 'free', status: 'active', complementary: false };
 	}
 
 	return svelteKitHandler({ event, resolve, auth, building });

--- a/src/lib/domain/recipe/recipe-service.boundary.spec.ts
+++ b/src/lib/domain/recipe/recipe-service.boundary.spec.ts
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS "user" (
   "image" text,
   "household_id" text REFERENCES "household"("id"),
   "household_role" text,
+  "complementary" boolean DEFAULT false NOT NULL,
   "created_at" timestamp DEFAULT now() NOT NULL,
   "updated_at" timestamp DEFAULT now() NOT NULL
 );

--- a/src/lib/domain/subscription/errors.ts
+++ b/src/lib/domain/subscription/errors.ts
@@ -1,0 +1,11 @@
+import { Data } from 'effect';
+
+export class SubscriptionRepositoryError extends Data.TaggedError('SubscriptionRepositoryError')<{
+	message: string;
+	cause?: unknown;
+}> {}
+
+export class SubscriptionRequiredError extends Data.TaggedError('SubscriptionRequiredError')<{
+	userId: string;
+	feature: string;
+}> {}

--- a/src/lib/domain/subscription/subscription-repository.ts
+++ b/src/lib/domain/subscription/subscription-repository.ts
@@ -1,0 +1,18 @@
+import { Context, Effect } from 'effect';
+import type { Subscription } from './subscription.js';
+import type { SubscriptionRepositoryError } from './errors.js';
+
+export class SubscriptionRepository extends Context.Tag('SubscriptionRepository')<
+	SubscriptionRepository,
+	{
+		readonly findByUserId: (
+			userId: string
+		) => Effect.Effect<Subscription | null, SubscriptionRepositoryError>;
+		readonly isComplementary: (
+			userId: string
+		) => Effect.Effect<boolean, SubscriptionRepositoryError>;
+		readonly findByHouseholdOwnerId: (
+			householdId: string
+		) => Effect.Effect<{ subscription: Subscription | null; isComplementary: boolean }, SubscriptionRepositoryError>;
+	}
+>() {}

--- a/src/lib/domain/subscription/subscription.ts
+++ b/src/lib/domain/subscription/subscription.ts
@@ -1,0 +1,12 @@
+export type SubscriptionTier = 'free' | 'solo';
+
+export type SubscriptionStatus = 'active' | 'cancelled' | 'expired';
+
+export type Feature = 'scan';
+
+export interface Subscription {
+	userId: string;
+	tier: SubscriptionTier;
+	status: SubscriptionStatus;
+	currentPeriodEnd: Date | null;
+}

--- a/src/lib/domain/subscription/use-cases.spec.ts
+++ b/src/lib/domain/subscription/use-cases.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { Effect, Layer } from 'effect';
+import { SubscriptionRepository } from './subscription-repository.js';
+import { checkFeatureAccess, getSubscription } from './use-cases.js';
+import { SubscriptionRequiredError } from './errors.js';
+import type { Subscription } from './subscription.js';
+
+const makeSubscription = (overrides: Partial<Subscription> = {}): Subscription => ({
+	userId: 'user-1',
+	tier: 'solo',
+	status: 'active',
+	currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+	...overrides
+});
+
+const makeRepo = (overrides: Partial<typeof SubscriptionRepository.Service> = {}) =>
+	Layer.succeed(SubscriptionRepository, {
+		findByUserId: () => Effect.succeed(null),
+		isComplementary: () => Effect.succeed(false),
+		findByHouseholdOwnerId: () =>
+			Effect.succeed({ subscription: null, isComplementary: false }),
+		...overrides
+	});
+
+describe('domain/subscription', () => {
+	describe('checkFeatureAccess', () => {
+		const accessResult = (userId: string, householdId: string | null, repo: ReturnType<typeof makeRepo>) =>
+			Effect.runPromise(
+				checkFeatureAccess(userId, householdId, 'scan').pipe(
+					Effect.provide(repo),
+					Effect.map(() => 'granted' as const),
+					Effect.catchTag('SubscriptionRequiredError', () => Effect.succeed('denied' as const))
+				)
+			);
+
+		it('grants access when user has complementary flag', async () => {
+			const result = await accessResult('user-1', null, makeRepo({ isComplementary: () => Effect.succeed(true) }));
+			expect(result).toBe('granted');
+		});
+
+		it('grants access when user has active solo subscription', async () => {
+			const result = await accessResult(
+				'user-1',
+				null,
+				makeRepo({ findByUserId: () => Effect.succeed(makeSubscription()) })
+			);
+			expect(result).toBe('granted');
+		});
+		it('grants access when cancelled but still within billing period', async () => {
+			const result = await accessResult(
+				'user-1',
+				null,
+				makeRepo({
+					findByUserId: () =>
+						Effect.succeed(
+							makeSubscription({
+								status: 'cancelled',
+								currentPeriodEnd: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+							})
+						)
+				})
+			);
+			expect(result).toBe('granted');
+		});
+
+		it('denies access when subscription is expired', async () => {
+			const result = await accessResult(
+				'user-1',
+				null,
+				makeRepo({
+					findByUserId: () =>
+						Effect.succeed(makeSubscription({ status: 'expired', currentPeriodEnd: new Date(Date.now() - 1000) }))
+				})
+			);
+			expect(result).toBe('denied');
+		});
+
+		it('denies access when user has no subscription', async () => {
+			const result = await accessResult('user-1', null, makeRepo());
+			expect(result).toBe('denied');
+		});
+
+		it('grants access when household owner has active subscription', async () => {
+			const result = await accessResult(
+				'member-1',
+				'hh-1',
+				makeRepo({
+					findByHouseholdOwnerId: () =>
+						Effect.succeed({
+							subscription: makeSubscription({ userId: 'owner-1' }),
+							isComplementary: false
+						})
+				})
+			);
+			expect(result).toBe('granted');
+		});
+
+		it('denies access when household owner has no subscription', async () => {
+			const result = await accessResult(
+				'member-1',
+				'hh-1',
+				makeRepo({
+					findByHouseholdOwnerId: () =>
+						Effect.succeed({ subscription: null, isComplementary: false })
+				})
+			);
+			expect(result).toBe('denied');
+		});
+
+		it('denies access when cancelled and past period end', async () => {
+			const result = await accessResult(
+				'user-1',
+				null,
+				makeRepo({
+					findByUserId: () =>
+						Effect.succeed(
+							makeSubscription({
+								status: 'cancelled',
+								currentPeriodEnd: new Date(Date.now() - 1000)
+							})
+						)
+				})
+			);
+			expect(result).toBe('denied');
+		});
+
+		it('grants access when household owner has complementary flag', async () => {
+			const result = await accessResult(
+				'member-1',
+				'hh-1',
+				makeRepo({
+					findByHouseholdOwnerId: () =>
+						Effect.succeed({ subscription: null, isComplementary: true })
+				})
+			);
+			expect(result).toBe('granted');
+		});
+	});
+
+	describe('getSubscription', () => {
+		it('returns subscription when found', async () => {
+			const sub = makeSubscription();
+			const result = await Effect.runPromise(
+				getSubscription('user-1').pipe(
+					Effect.provide(makeRepo({ findByUserId: () => Effect.succeed(sub) }))
+				)
+			);
+			expect(result).toEqual(sub);
+		});
+
+		it('returns null when no subscription exists', async () => {
+			const result = await Effect.runPromise(
+				getSubscription('user-1').pipe(Effect.provide(makeRepo()))
+			);
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/src/lib/domain/subscription/use-cases.ts
+++ b/src/lib/domain/subscription/use-cases.ts
@@ -1,0 +1,41 @@
+import { Effect } from 'effect';
+import { SubscriptionRepository } from './subscription-repository.js';
+import { SubscriptionRequiredError } from './errors.js';
+import type { Feature, Subscription } from './subscription.js';
+
+const hasAccess = (subscription: Subscription | null): boolean => {
+	if (!subscription) return false;
+	if (subscription.status === 'active') return true;
+	if (
+		subscription.status === 'cancelled' &&
+		subscription.currentPeriodEnd &&
+		subscription.currentPeriodEnd > new Date()
+	)
+		return true;
+	return false;
+};
+
+export const checkFeatureAccess = (userId: string, householdId: string | null, feature: Feature) =>
+	Effect.gen(function* () {
+		const repo = yield* SubscriptionRepository;
+		const complementary = yield* repo.isComplementary(userId);
+		if (complementary) return;
+
+		const subscription = yield* repo.findByUserId(userId);
+		if (hasAccess(subscription)) return;
+
+		// Fall back to household owner's subscription
+		if (householdId) {
+			const owner = yield* repo.findByHouseholdOwnerId(householdId);
+			if (owner.isComplementary) return;
+			if (hasAccess(owner.subscription)) return;
+		}
+
+		return yield* Effect.fail(new SubscriptionRequiredError({ userId, feature }));
+	});
+
+export const getSubscription = (userId: string) =>
+	Effect.gen(function* () {
+		const repo = yield* SubscriptionRepository;
+		return yield* repo.findByUserId(userId);
+	});

--- a/src/lib/infrastructure/drizzle-subscription-repository.ts
+++ b/src/lib/infrastructure/drizzle-subscription-repository.ts
@@ -1,0 +1,54 @@
+import { Layer, Effect } from 'effect';
+import { eq, and } from 'drizzle-orm';
+import { SubscriptionRepository } from '$lib/domain/subscription/subscription-repository.js';
+import { SubscriptionRepositoryError } from '$lib/domain/subscription/errors.js';
+import { Database } from './database.js';
+import { user } from '$lib/server/db/schema';
+
+export const DrizzleSubscriptionRepository = Layer.effect(
+	SubscriptionRepository,
+	Effect.gen(function* () {
+		const db = yield* Database;
+		return {
+			findByUserId: () =>
+				Effect.tryPromise({
+					try: async () => null,
+					catch: (cause) => new SubscriptionRepositoryError({ message: 'Failed to find subscription', cause })
+				}),
+
+			isComplementary: (userId) =>
+				Effect.tryPromise({
+					try: async () => {
+						const [row] = await db
+							.select({ complementary: user.complementary })
+							.from(user)
+							.where(eq(user.id, userId))
+							.limit(1);
+						return row?.complementary ?? false;
+					},
+					catch: (cause) =>
+						new SubscriptionRepositoryError({ message: 'Failed to check complementary status', cause })
+				}),
+
+			findByHouseholdOwnerId: (householdId) =>
+				Effect.tryPromise({
+					try: async () => {
+						const [owner] = await db
+							.select({ complementary: user.complementary })
+							.from(user)
+							.where(and(eq(user.householdId, householdId), eq(user.householdRole, 'owner')))
+							.limit(1);
+						return {
+							subscription: null,
+							isComplementary: owner?.complementary ?? false
+						};
+					},
+					catch: (cause) =>
+						new SubscriptionRepositoryError({
+							message: 'Failed to find household owner subscription',
+							cause
+						})
+				})
+		};
+	})
+);

--- a/src/lib/server/db/auth.schema.ts
+++ b/src/lib/server/db/auth.schema.ts
@@ -20,6 +20,7 @@ export const user = pgTable('user', {
 	image: text('image'),
 	householdId: text('household_id').references(() => household.id),
 	householdRole: householdRoleEnum('household_role'),
+	complementary: boolean('complementary').default(false).notNull(),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 	updatedAt: timestamp('updated_at')
 		.defaultNow()

--- a/src/lib/server/runtime.ts
+++ b/src/lib/server/runtime.ts
@@ -8,6 +8,7 @@ import { DrizzleAICanonicalIngredientResolver } from '$lib/infrastructure/drizzl
 import { AIRecipeScannerLive } from '$lib/infrastructure/ai-recipe-scanner.js';
 import { AIReceiptScannerLive } from '$lib/infrastructure/ai-receipt-scanner.js';
 import { DrizzleHouseholdRepository } from '$lib/infrastructure/drizzle-household-repository.js';
+import { DrizzleSubscriptionRepository } from '$lib/infrastructure/drizzle-subscription-repository.js';
 import { DatabaseLive } from '$lib/infrastructure/database.js';
 
 const AppLive = Layer.mergeAll(
@@ -18,7 +19,8 @@ const AppLive = Layer.mergeAll(
 	DrizzleAICanonicalIngredientResolver,
 	AIRecipeScannerLive,
 	AIReceiptScannerLive,
-	DrizzleHouseholdRepository
+	DrizzleHouseholdRepository,
+	DrizzleSubscriptionRepository
 ).pipe(
 	Layer.provide(DatabaseLive),
 	Layer.provide(dev ? Logger.pretty : Logger.json)

--- a/src/routes/api/scan-food/+server.ts
+++ b/src/routes/api/scan-food/+server.ts
@@ -5,10 +5,21 @@ import { withRequestLogging } from '$lib/server/logging';
 import { appRuntime } from '$lib/server/runtime.js';
 import { extractItemsFromReceipt } from '$lib/domain/receipt/use-cases.js';
 import { AIFoodPhotoScannerLive } from '$lib/infrastructure/ai-food-photo-scanner.js';
+import { checkFeatureAccess } from '$lib/domain/subscription/use-cases.js';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user) {
 		error(401, 'Unauthorized');
+	}
+
+	const accessResult = await appRuntime.runPromise(
+		checkFeatureAccess(locals.user.id, locals.householdId ?? null, 'scan').pipe(
+			Effect.map(() => 'granted' as const),
+			Effect.catchTag('SubscriptionRequiredError', () => Effect.succeed('denied' as const))
+		)
+	);
+	if (accessResult === 'denied') {
+		error(403, 'This feature requires an active subscription.');
 	}
 
 	const formData = await request.formData();

--- a/src/routes/api/scan-food/scan-food-server.spec.ts
+++ b/src/routes/api/scan-food/scan-food-server.spec.ts
@@ -8,6 +8,11 @@ import {
 
 const { mockExtractItems } = vi.hoisted(() => ({ mockExtractItems: vi.fn() }));
 
+vi.mock('$lib/domain/subscription/use-cases.js', async () => {
+	const { Effect } = await import('effect');
+	return { checkFeatureAccess: () => Effect.succeed(undefined) };
+});
+
 vi.mock('$lib/server/runtime.js', async () => {
 	const { Effect } = await import('effect');
 	return {

--- a/src/routes/api/scan-receipt/+server.ts
+++ b/src/routes/api/scan-receipt/+server.ts
@@ -4,10 +4,21 @@ import type { RequestHandler } from './$types';
 import { withRequestLogging } from '$lib/server/logging';
 import { appRuntime } from '$lib/server/runtime.js';
 import { extractItemsFromReceipt } from '$lib/domain/receipt/use-cases.js';
+import { checkFeatureAccess } from '$lib/domain/subscription/use-cases.js';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user) {
 		error(401, 'Unauthorized');
+	}
+
+	const accessResult = await appRuntime.runPromise(
+		checkFeatureAccess(locals.user.id, locals.householdId ?? null, 'scan').pipe(
+			Effect.map(() => 'granted' as const),
+			Effect.catchTag('SubscriptionRequiredError', () => Effect.succeed('denied' as const))
+		)
+	);
+	if (accessResult === 'denied') {
+		error(403, 'This feature requires an active subscription.');
 	}
 
 	const formData = await request.formData();

--- a/src/routes/api/scan-receipt/scan-receipt-server.spec.ts
+++ b/src/routes/api/scan-receipt/scan-receipt-server.spec.ts
@@ -8,6 +8,11 @@ import {
 
 const { mockExtractItems } = vi.hoisted(() => ({ mockExtractItems: vi.fn() }));
 
+vi.mock('$lib/domain/subscription/use-cases.js', async () => {
+	const { Effect } = await import('effect');
+	return { checkFeatureAccess: () => Effect.succeed(undefined) };
+});
+
 vi.mock('$lib/infrastructure/ai-receipt-scanner.js', async () => {
 	const { Layer } = await import('effect');
 	const { ReceiptScanner } = await import('$lib/domain/receipt/receipt-scanner.js');

--- a/src/routes/api/scan-recipe/+server.ts
+++ b/src/routes/api/scan-recipe/+server.ts
@@ -4,10 +4,21 @@ import type { RequestHandler } from './$types';
 import { withRequestLogging } from '$lib/server/logging';
 import { appRuntime } from '$lib/server/runtime.js';
 import { RecipeScanner } from '$lib/domain/recipe/recipe-scanner.js';
+import { checkFeatureAccess } from '$lib/domain/subscription/use-cases.js';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user) {
 		error(401, 'Unauthorized');
+	}
+
+	const accessResult = await appRuntime.runPromise(
+		checkFeatureAccess(locals.user.id, locals.householdId ?? null, 'scan').pipe(
+			Effect.map(() => 'granted' as const),
+			Effect.catchTag('SubscriptionRequiredError', () => Effect.succeed('denied' as const))
+		)
+	);
+	if (accessResult === 'denied') {
+		error(403, 'This feature requires an active subscription.');
 	}
 
 	const formData = await request.formData();

--- a/src/routes/api/scan-recipe/scan-recipe-server.spec.ts
+++ b/src/routes/api/scan-recipe/scan-recipe-server.spec.ts
@@ -8,6 +8,11 @@ import {
 
 const { mockExtractRecipes } = vi.hoisted(() => ({ mockExtractRecipes: vi.fn() }));
 
+vi.mock('$lib/domain/subscription/use-cases.js', async () => {
+	const { Effect } = await import('effect');
+	return { checkFeatureAccess: () => Effect.succeed(undefined) };
+});
+
 vi.mock('$lib/infrastructure/ai-recipe-scanner.js', async () => {
 	const { Layer } = await import('effect');
 	const { RecipeScanner } = await import('$lib/domain/recipe/recipe-scanner.js');


### PR DESCRIPTION
Introduce pure subscription domain module with checkFeatureAccess and getSubscription use cases, abstract SubscriptionRepository, and stub Drizzle implementation. Add complementary boolean to user table. Gate scan API routes (receipt, food, recipe) behind subscription check — free-tier users receive 403. Household members inherit access from their owner's subscription or complementary flag. Populate locals.subscription in hooks.server.ts for downstream UI use.